### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ali818/128f7dde-f1a4-42d6-9417-802b39f5434a/2a8d7e00-9b93-4511-84e9-b8fe0e3724b9/_apis/work/boardbadge/60320eeb-8059-420c-b128-49d6f0c979c4)](https://dev.azure.com/ali818/128f7dde-f1a4-42d6-9417-802b39f5434a/_boards/board/t/2a8d7e00-9b93-4511-84e9-b8fe0e3724b9/Microsoft.RequirementCategory)
 # AWS Toolkit for Visual Studio Code
 
 [![Coverage](https://img.shields.io/codecov/c/github/aws/aws-toolkit-vscode/master.svg)](https://codecov.io/gh/aws/aws-toolkit-vscode/branch/master) [![Marketplace Version](https://img.shields.io/vscode-marketplace/v/AmazonWebServices.aws-toolkit-vscode.svg) ![Marketplace Downloads](https://img.shields.io/vscode-marketplace/d/AmazonWebServices.aws-toolkit-vscode.svg)](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ali818/128f7dde-f1a4-42d6-9417-802b39f5434a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.